### PR TITLE
Add toast animation on enter/leave

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,11 @@ updates:
           - '*'
     schedule:
       interval: 'weekly'
-  - package-ecosystem: "npm"
-    directory: "/"
+  - package-ecosystem: 'npm'
+    directory: '/'
     groups:
       npm-dependencies:
         patterns:
-          - "*"
+          - '*'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-<img alt="react-hot-toast - Try it out" src="https://res.cloudinary.com/ddlhtsgmp/image/upload/w_300,h_300,c_fill,r_10/v1755055178/lit-toaster-logo-full.png"/>
+<img alt="lit toaster logo" src="https://res.cloudinary.com/ddlhtsgmp/image/upload/w_300,h_300,c_fill,r_10/v1755055178/lit-toaster-logo-full.png"/>
 </div>
 
 <br />

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -7,3 +7,4 @@ export const TOAST_TYPES: readonly ToastKind[] = [
   'warning',
   'info',
 ];
+export const TOAST_ANIMATION_DURATION = 200; // In milliseconds

--- a/src/testing/mocks/toast.ts
+++ b/src/testing/mocks/toast.ts
@@ -1,0 +1,18 @@
+import { Toast, ToastKind, ToastPosition } from '../../types';
+
+/** Get mock toast object */
+export function getToastObject(
+  message: string = 'This is a toast message!',
+  duration: number = 7000,
+  type: ToastKind = 'success',
+  position: ToastPosition = 'top-center'
+): Toast {
+  return {
+    id: '',
+    message,
+    duration,
+    type,
+    position,
+    state: 'enter',
+  };
+}

--- a/src/toast-emitter.ts
+++ b/src/toast-emitter.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_TOASTS_LIMIT } from './constants.ts';
+import { DEFAULT_TOASTS_LIMIT, TOAST_ANIMATION_DURATION } from './constants.ts';
 import { Toast, ToastEmitterEvent, ToastKind, ToastPosition } from './types.ts';
 import { GUID } from './utils.ts';
 
@@ -62,6 +62,7 @@ export class ToastEmitter extends EventTarget {
           duration,
           type: 'warning',
           position: 'bottom-center',
+          state: 'enter',
         };
         this._toasts = [...this._toasts, warningToast];
         this.emitToastsChange();
@@ -80,9 +81,10 @@ export class ToastEmitter extends EventTarget {
       duration,
       type,
       position,
+      state: 'enter',
     };
 
-    this._toasts = [...this._toasts, newToast];
+    this._toasts = [newToast, ...this._toasts];
     this.emitToastsChange();
 
     // Toast will not auto remove if duration `-1` - onClick to close toast
@@ -93,11 +95,18 @@ export class ToastEmitter extends EventTarget {
 
   /**
    * Remove toast
-   * @param t
+   * @param toast
    */
-  public remove(t: Toast): void {
-    this._toasts = this._toasts.filter((item) => item !== t);
+  public remove(toast: Toast): void {
+    const index = this._toasts.indexOf(toast);
+    if (index === -1) return;
+    this._toasts[index as number].state = 'leave';
     this.emitToastsChange();
+
+    setTimeout(() => {
+      this._toasts = this._toasts.filter((item) => item !== toast);
+      this.emitToastsChange();
+    }, TOAST_ANIMATION_DURATION);
   }
 
   /**

--- a/src/toaster-element.ts
+++ b/src/toaster-element.ts
@@ -79,7 +79,7 @@ export class ToasterElement extends LitElement {
               (toast) => html`
                 <div
                   id="toast-${toast.type}-${toast.id}"
-                  class="toast"
+                  class="toast ${toast.state}"
                   role="alert"
                 >
                   <div class="toast-${toast.type} toast-icon">
@@ -183,7 +183,7 @@ export class ToasterElement extends LitElement {
         0 1px 3px #0000001a;
     }
 
-    /** Screen ready only */
+    /** Screen reader only */
     .sr-only {
       position: absolute;
       width: 1px;
@@ -294,6 +294,39 @@ export class ToasterElement extends LitElement {
       right: 10px;
       align-items: flex-end;
       flex-direction: column-reverse;
+    }
+
+    .toast.enter {
+      animation: onToastEnter 250ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+    }
+
+    .toast.leave {
+      animation: onToastLeave 200ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+    }
+
+    @keyframes onToastEnter {
+      from {
+        opacity: 0;
+        transform: translateY(12px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    @keyframes onToastLeave {
+      0% {
+        opacity: 1;
+        transform: translateY(0) scaleY(1);
+      }
+      50% {
+        transform: translateY(4px) scaleY(0.95);
+      }
+      100% {
+        opacity: 0;
+        transform: translateY(24px) scaleY(0.8);
+      }
     }
 
     /* Apply dark mode styles if user’s system or browser theme is set to 'dark' */

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,12 +6,15 @@ export type ToastPosition =
   | 'bottom-left'
   | 'bottom-right'
   | 'bottom-center';
+/** The animation state of a toast */
+export type ToastState = 'enter' | 'leave';
 export type Toast = {
   id: string;
   message: string;
   duration: number;
   type: ToastKind;
   position: ToastPosition;
+  state: ToastState;
 };
 /**
  * Enum representing the custom event types emitted by the `ToastEmitter`


### PR DESCRIPTION
## Changes
- Add toast animation on enter/leave
   - Add subtle animation styles
   - Add type `ToastState` and  toast object `state` prop for animation state tracking
 - Fix mocking (`setTimeout()`) timing in unit tests

## Linked Issues
#7 