### PR TITLE
Replace queue text with toasts text

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ declare global {
 
 ## Toaster element properties
 
-| Name         | Attribute |
-| ------------ | --------- |
-| `queueLimit` | false     |
+| Name          | Attribute |
+| ------------- | --------- |
+| `toastsLimit` | false     |
 
 ## Documentation
 

--- a/src/tests/toast-emitter.test.ts
+++ b/src/tests/toast-emitter.test.ts
@@ -8,18 +8,18 @@ import { TOAST_ANIMATION_DURATION } from '../constants.ts';
 
 describe('Toast Emitter', () => {
   let toast!: ToastEmitter | null;
-  let onQueueLimitChange: ReturnType<typeof vi.fn>;
+  let onToastsLimitChange: ReturnType<typeof vi.fn>;
   let onToastsChange: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     vi.useFakeTimers();
     vi.resetAllMocks();
     toast = new ToastEmitter();
-    onQueueLimitChange = vi.fn();
+    onToastsLimitChange = vi.fn();
     onToastsChange = vi.fn();
     toast?.addEventListener(
-      ToastEmitterEvent.QUEUE_LIMIT_CHANGE,
-      onQueueLimitChange
+      ToastEmitterEvent.TOASTS_LIMIT_CHANGE,
+      onToastsLimitChange
     );
     toast?.addEventListener(ToastEmitterEvent.TOASTS_CHANGE, onToastsChange);
   });
@@ -27,8 +27,8 @@ describe('Toast Emitter', () => {
   afterEach(() => {
     if (toast) {
       toast?.addEventListener(
-        ToastEmitterEvent.QUEUE_LIMIT_CHANGE,
-        onQueueLimitChange
+        ToastEmitterEvent.TOASTS_LIMIT_CHANGE,
+        onToastsLimitChange
       );
       toast.removeEventListener(
         ToastEmitterEvent.TOASTS_CHANGE,
@@ -39,12 +39,12 @@ describe('Toast Emitter', () => {
     vi.useRealTimers();
   });
 
-  describe(`${ToastEmitterEvent.QUEUE_LIMIT_CHANGE} event`, () => {
-    it('dispatches event via queueLimit setter', () => {
-      const updatedQueueLimit = 10;
-      toast.queueLimit = updatedQueueLimit;
-      expect((toast as any)._queueLimit).toEqual(updatedQueueLimit);
-      expect(onQueueLimitChange).toHaveBeenCalledTimes(1);
+  describe(`${ToastEmitterEvent.TOASTS_LIMIT_CHANGE} event`, () => {
+    it('dispatches event via toastsLimit setter', () => {
+      const updatedToastsLimit = 10;
+      toast.toastsLimit = updatedToastsLimit;
+      expect((toast as any)._toastsLimit).toEqual(updatedToastsLimit);
+      expect(onToastsLimitChange).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -125,41 +125,41 @@ describe('Toast Emitter', () => {
     });
 
     it(`dispatches ${ToastEmitterEvent.TOASTS_CHANGE} event via show() method for 'Too many notifications' warning`, () => {
-      let queueLimitWarningToast: Toast = getToastObject(
+      let toastsLimitWarningToast: Toast = getToastObject(
         'Too many notifications. Please wait a moment and/or close existing ones.',
         undefined,
         'warning',
         'bottom-center'
       );
-      for (let i = 0; i <= toast._queueLimit - 1; i++) {
+      for (let i = 0; i <= toast._toastsLimit - 1; i++) {
         toast?.show('This is a toast message!', 7000, 'success', 'top-center');
       }
       expect(toast?.toasts.length).toEqual(7);
-      queueLimitWarningToast.id = toast?.toasts[6].id;
-      expect(toast?.toasts[6]).toEqual(queueLimitWarningToast);
+      toastsLimitWarningToast.id = toast?.toasts[0].id;
+      expect(toast?.toasts[0]).toEqual(toastsLimitWarningToast);
     });
   });
 
-  describe('queueLimit setter', () => {
-    it('sets new queueLimit from number value', () => {
-      const newQueueLimit = 10;
-      toast.queueLimit = newQueueLimit;
-      expect(toast?._queueLimit).toBeDefined();
-      expect(toast?._queueLimit).toBeTypeOf('number');
-      expect(toast?._queueLimit).toEqual(newQueueLimit);
+  describe('toastsLimit setter', () => {
+    it('sets new toastsLimit from number value', () => {
+      const newToastsLimit = 10;
+      toast.toastsLimit = newToastsLimit;
+      expect(toast?._toastsLimit).toBeDefined();
+      expect(toast?._toastsLimit).toBeTypeOf('number');
+      expect(toast?._toastsLimit).toEqual(newToastsLimit);
     });
 
-    it('sets new queueLimit value from string (number) value', () => {
+    it('sets new toastsLimit value from string (number) value', () => {
       const toast = new ToastEmitter();
-      const newQueueLimit = '10';
-      toast.queueLimit = newQueueLimit;
-      expect(toast?._queueLimit).toBeDefined();
-      expect(toast?._queueLimit).toBeTypeOf('number');
-      expect(toast?._queueLimit).toEqual(Number(10));
+      const newToastsLimit = '10';
+      toast.toastsLimit = newToastsLimit;
+      expect(toast?._toastsLimit).toBeDefined();
+      expect(toast?._toastsLimit).toBeTypeOf('number');
+      expect(toast?._toastsLimit).toEqual(Number(10));
     });
 
-    it('sets queueLimit to provided valid value or default if new value is not typeof number', () => {
-      const defaultValue = toast._queueLimit;
+    it('sets toastsLimit to provided valid value or default if new value is not typeof number', () => {
+      const defaultValue = toast._toastsLimit;
       const validValue = 10;
       const cases = [
         {},
@@ -173,28 +173,28 @@ describe('Toast Emitter', () => {
 
       // Sets default value
       for (const i of cases) {
-        toast.queueLimit = i;
-        expect(toast?._queueLimit).toBeDefined();
-        expect(toast?._queueLimit).toBeTypeOf('number');
-        expect(toast._queueLimit).toEqual(defaultValue);
+        toast.toastsLimit = i;
+        expect(toast?._toastsLimit).toBeDefined();
+        expect(toast?._toastsLimit).toBeTypeOf('number');
+        expect(toast._toastsLimit).toEqual(defaultValue);
       }
 
-      toast.queueLimit = validValue;
+      toast.toastsLimit = validValue;
       // Sets to previous valid value
       for (const i of cases) {
-        toast.queueLimit = i;
-        expect(toast?._queueLimit).toBeDefined();
-        expect(toast?._queueLimit).toBeTypeOf('number');
-        expect(toast._queueLimit).toEqual(validValue);
+        toast.toastsLimit = i;
+        expect(toast?._toastsLimit).toBeDefined();
+        expect(toast?._toastsLimit).toBeTypeOf('number');
+        expect(toast._toastsLimit).toEqual(validValue);
       }
     });
 
-    it(`sets new queueLimit value to 0 (no limit) if provided value is less than 0`, () => {
-      const newQueueLimit = -10;
-      toast.queueLimit = newQueueLimit;
-      expect(toast?._queueLimit).toBeDefined();
-      expect(toast?._queueLimit).toBeTypeOf('number');
-      expect(toast?._queueLimit).toEqual(0);
+    it(`sets new toastsLimit value to 0 (no limit) if provided value is less than 0`, () => {
+      const newToastsLimit = -10;
+      toast.toastsLimit = newToastsLimit;
+      expect(toast?._toastsLimit).toBeDefined();
+      expect(toast?._toastsLimit).toBeTypeOf('number');
+      expect(toast?._toastsLimit).toEqual(0);
     });
   });
 });

--- a/src/tests/toaster-element.test.ts
+++ b/src/tests/toaster-element.test.ts
@@ -68,35 +68,35 @@ describe('<app-toaster> element', () => {
   });
 
   describe('properties', () => {
-    describe('queueLimit', () => {
+    describe('toastsLimit', () => {
       it('has undefined default value', async () => {
-        const toastQueueLimitDefault = 7;
+        const toastToastsLimitDefault = 7;
         expect(appToasterElement).toBeDefined();
-        expect(appToasterElement?.queueLimit).toBeUndefined();
+        expect(appToasterElement?.toastsLimit).toBeUndefined();
 
-        // Element property undefined, yet toast (emitter) queueLimit will still take effect
-        expect((toast as any)._queueLimit).toEqual(toastQueueLimitDefault);
+        // Element property undefined, yet toast (emitter) toastsLimit will still take effect
+        expect((toast as any)._toastsLimit).toEqual(toastToastsLimitDefault);
       });
 
-      it('updates when set with new value and updates ToastEmitter queueLimit instance variable', async () => {
-        const newQueueLimit = 10;
+      it('updates when set with new value and updates ToastEmitter toastsLimit instance variable', async () => {
+        const newToastsLimit = 10;
         expect(appToasterElement).toBeDefined();
-        expect(appToasterElement?.queueLimit).toBeUndefined();
+        expect(appToasterElement?.toastsLimit).toBeUndefined();
 
-        appToasterElement.queueLimit = newQueueLimit;
+        appToasterElement.toastsLimit = newToastsLimit;
         // Element property set, so toast (emitter) get's set to same value
-        expect((toast as any)._queueLimit).toEqual(newQueueLimit);
+        expect((toast as any)._toastsLimit).toEqual(newToastsLimit);
       });
 
-      it('updates when set with new value via ToastEmitter queueLimit setter', async () => {
-        const newQueueLimit = 10;
+      it('updates when set with new value via ToastEmitter toastsLimit setter', async () => {
+        const newToastsLimit = 10;
         expect(appToasterElement).toBeDefined();
-        expect(appToasterElement?.queueLimit).toBeUndefined();
+        expect(appToasterElement?.toastsLimit).toBeUndefined();
 
-        toast.queueLimit = newQueueLimit;
+        toast.toastsLimit = newToastsLimit;
 
-        expect((toast as any)._queueLimit).toEqual(newQueueLimit);
-        expect(appToasterElement.queueLimit).toEqual(newQueueLimit);
+        expect((toast as any)._toastsLimit).toEqual(newToastsLimit);
+        expect(appToasterElement.toastsLimit).toEqual(newToastsLimit);
       });
     });
   });

--- a/src/toast-emitter.ts
+++ b/src/toast-emitter.ts
@@ -3,7 +3,7 @@ import { Toast, ToastEmitterEvent, ToastKind, ToastPosition } from './types.ts';
 import { GUID } from './utils.ts';
 
 export class ToastEmitter extends EventTarget {
-  private _queueLimit: number = DEFAULT_TOASTS_LIMIT;
+  private _toastsLimit: number = DEFAULT_TOASTS_LIMIT;
   private _toasts: Toast[] = [];
 
   /**
@@ -13,23 +13,23 @@ export class ToastEmitter extends EventTarget {
     return this._toasts;
   }
 
-  /** Set toasts queue limit */
-  public set queueLimit(value: string | number) {
-    let updatedQueueLimit = this._queueLimit;
+  /** Set toasts limit */
+  public set toastsLimit(value: string | number) {
+    let updatedToastsLimit = this._toastsLimit;
 
     if (typeof value === 'number') {
-      updatedQueueLimit = value;
+      updatedToastsLimit = value;
     }
 
     if (typeof value === 'string') {
       const valueToNum = Number(value);
       if (!isNaN(valueToNum)) {
-        updatedQueueLimit = valueToNum;
+        updatedToastsLimit = valueToNum;
       }
     }
 
-    this._queueLimit = Math.max(0, updatedQueueLimit); // Set any negative value to 0
-    this.emitQueueLimitChange();
+    this._toastsLimit = Math.max(0, updatedToastsLimit); // Set any negative value to 0
+    this.emitToastsLimitChange();
   }
 
   /**
@@ -45,8 +45,8 @@ export class ToastEmitter extends EventTarget {
     type: ToastKind = 'success',
     position: ToastPosition = 'top-center'
   ): void {
-    // Check if next toast added will hit the queue limit. Less than 0 = no limit
-    if (this._queueLimit > 0 && this._toasts.length + 1 >= this._queueLimit) {
+    // Check if next toast added will hit the toasts limit. Less than 0 = no limit
+    if (this._toastsLimit > 0 && this._toasts.length + 1 >= this._toastsLimit) {
       // Only add a warning toast if one isn't already present
       const existingWarningToast = this._toasts.find(
         (t) =>
@@ -64,7 +64,7 @@ export class ToastEmitter extends EventTarget {
           position: 'bottom-center',
           state: 'enter',
         };
-        this._toasts = [...this._toasts, warningToast];
+        this._toasts = [warningToast, ...this._toasts];
         this.emitToastsChange();
         setTimeout(() => this.remove(warningToast), duration);
       }
@@ -110,12 +110,12 @@ export class ToastEmitter extends EventTarget {
   }
 
   /**
-   * Dispatch `queue-limit-change` event
+   * Dispatch `toasts-limit-change` event
    */
-  private emitQueueLimitChange(): void {
+  private emitToastsLimitChange(): void {
     this.dispatchEvent(
-      new CustomEvent(ToastEmitterEvent.QUEUE_LIMIT_CHANGE, {
-        detail: this._queueLimit,
+      new CustomEvent(ToastEmitterEvent.TOASTS_LIMIT_CHANGE, {
+        detail: this._toastsLimit,
       })
     );
   }

--- a/src/toaster-element.ts
+++ b/src/toaster-element.ts
@@ -7,27 +7,27 @@ import { TOAST_TYPES } from './constants.ts';
 @customElement('app-toaster')
 export class ToasterElement extends LitElement {
   @property({ type: Number, attribute: false })
-  set queueLimit(value: number | undefined) {
-    this._queueLimit = value;
+  set toastsLimit(value: number | undefined) {
+    this._toastsLimit = value;
     if (value !== undefined) {
-      // Update ToastEmitter queueLimit instance variable value to match element queueLimit property value
-      toast.queueLimit = value;
+      // Update ToastEmitter toastsLimit instance variable value to match element toastsLimit property value
+      toast.toastsLimit = value;
     }
   }
-  get queueLimit(): number | undefined {
-    return this._queueLimit;
+  get toastsLimit(): number | undefined {
+    return this._toastsLimit;
   }
   @state()
   private _toastsList: Toast[] = [];
   @state()
-  private _queueLimit?: number;
+  private _toastsLimit?: number;
 
   // Add/remove event listeners for ToastEmitter events
   connectedCallback(): void {
     super.connectedCallback();
     toast.addEventListener(
-      ToastEmitterEvent.QUEUE_LIMIT_CHANGE,
-      this.onQueueLimitChange
+      ToastEmitterEvent.TOASTS_LIMIT_CHANGE,
+      this.onToastsLimitChange
     );
     toast.addEventListener(
       ToastEmitterEvent.TOASTS_CHANGE,
@@ -38,8 +38,8 @@ export class ToasterElement extends LitElement {
   disconnectedCallback(): void {
     super.disconnectedCallback();
     toast.removeEventListener(
-      ToastEmitterEvent.QUEUE_LIMIT_CHANGE,
-      this.onQueueLimitChange
+      ToastEmitterEvent.TOASTS_LIMIT_CHANGE,
+      this.onToastsLimitChange
     );
     toast.removeEventListener(
       ToastEmitterEvent.TOASTS_CHANGE,
@@ -50,7 +50,7 @@ export class ToasterElement extends LitElement {
   /**
    * A map that groups each toast position with its own list of toasts
    * @example { "top-left": [Toast, Toast], "bottom-right": [Toast], ... }
-   * @satisfies Ensures each position’s toast queue has its own independent index starting at 0
+   * @satisfies Ensures each position’s toast stack has its own independent index starting at 0
    */
   private get groupedToasts(): Record<ToastPosition, Toast[]> {
     const toastGroups = {} as Record<ToastPosition, Toast[]>;
@@ -132,14 +132,14 @@ export class ToasterElement extends LitElement {
   }
 
   /**
-   * Handle toast `queue-limit-change` event - get updated queue limit
+   * Handle toast `toasts-limit-change` event - get updated toasts limit
    * @param event
    */
-  private onQueueLimitChange = (event: Event): void => {
+  private onToastsLimitChange = (event: Event): void => {
     if (event instanceof CustomEvent) {
-      // Update element queueLimit property value to match ToastEmitter queueLimit instance variable value
-      if (event.detail !== undefined && this._queueLimit !== event.detail) {
-        this._queueLimit = event.detail;
+      // Update element toastsLimit property value to match ToastEmitter toastsLimit instance variable value
+      if (event.detail !== undefined && this._toastsLimit !== event.detail) {
+        this._toastsLimit = event.detail;
         this.requestUpdate();
       }
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,9 +22,9 @@ export type Toast = {
  */
 export enum ToastEmitterEvent {
   /**
-   * Dispatched when the queue limit changes via the `queueLimit` setter. Event detail (`event.detail`) contains the updated queue limit as a number
+   * Dispatched when the toasts limit changes via the `toastsLimit` setter. Event detail (`event.detail`) contains the updated toasts limit as a number
    */
-  QUEUE_LIMIT_CHANGE = 'queue-limit-change',
+  TOASTS_LIMIT_CHANGE = 'toasts-limit-change',
   /**
    * Dispatched when a new toast is added to the toasts list via the `show()` method. Event detail (`event.detail`) contains the updated toasts list as an array
    */


### PR DESCRIPTION
## Changes
- Replace `queue` text with `toasts` text
  - Toasts no longer queue but instead stack after recent PR #7 changes - updating text to match new toasts behavior