### PR TITLE
fix(toaster-element): prevent "global is not defined" error in Rollup by treating file as a module

### DIFF
--- a/src/toaster-element.ts
+++ b/src/toaster-element.ts
@@ -339,6 +339,13 @@ export class ToasterElement extends LitElement {
   `;
 }
 
+/**
+ * Forces this file to be treated as a module.
+ * Temp fix: this prevents Rollup from throwing "global is not defined" error
+ * when generating type declarations for files without explicit exports.
+ */
+export {};
+
 declare global {
   interface HTMLElementTagNameMap {
     'app-toaster': ToasterElement;

--- a/src/typings.ts
+++ b/src/typings.ts
@@ -1,4 +1,4 @@
 // Exporting all to generate one combined declaration file with bundler
 export { toast } from './toast-emitter.ts';
-export * from './toaster-element.ts';
+export { ToasterElement } from './toaster-element.ts';
 export * from './types.ts';


### PR DESCRIPTION
## Changes
- Add `export {}` and the end of `toaster-element` file to force file to be treated as a module - prevents Rollup from throwing `global is not defined` error

## Additional details
- This is a temp solution (workaround). I didn't see this error until bumping deps #49 