### PR TITLE
chore(workflows): remove NODE_AUTH_TOKEN from npm publish step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -66,5 +66,3 @@ jobs:
       # NPM Release
       - name: Publish the release to NPM
         run: npm publish --provenance --access public --tag ${{ steps.fallback_tag.outputs.tag }}
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
## Changes
- Remove `NODE_AUTH_TOKEN` from npm publish step

## Additional Details
- Switching to trusted publishing using OpenID Connect (OIDC)